### PR TITLE
Auto install shell completion

### DIFF
--- a/Formula/xcodes.rb
+++ b/Formula/xcodes.rb
@@ -12,6 +12,7 @@ class Xcodes < Formula
 
   def install
     system "make", "install", "prefix=#{prefix}"
+    generate_completions_from_executable(bin/"xcodes", "--generate-completion-script")
   end
 
   test do


### PR DESCRIPTION
This small change will free users from having to manually call `xcodes --generate-shell-completion` and put it in the appropriate location.

Examples of formulas where it's already done:
- [cirrus](https://github.com/cirruslabs/homebrew-cli/blob/113a952eaacde8fa458da272361cad44c311d073/cirrus.rb#L49-L52)
- [tart](https://github.com/cirruslabs/homebrew-cli/blob/113a952eaacde8fa458da272361cad44c311d073/tart.rb#L28-L33)